### PR TITLE
Add a <select> full of advocates on Rights confirmation page

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,6 +17,8 @@
 //= require materialize/global
 //= require materialize/forms
 //= require materialize/character_counter
+//= require materialize/dropdown
+//= require materialize/jquery.easing.1.3
 //= require_tree .
 
 const analytics = {
@@ -128,10 +130,27 @@ window.App = (function() {
 
       $(document).on('click', 'tr[data-href]', handleTableClick);
     },
+
+    onPageLoad: function(e) {
+      // This method is called after a page is loaded, either for the first time
+      // or via turbolinks.
+      //
+      // Since turbolinks effectively turns this site into a single-page app,
+      // any event listeners created here for elements on this page should be
+      // removed on `onPageOffload`.
+      $('select').material_select();
+
+      analytics.trackView(e);
+    },
+
+    onPageOffload: function() {
+      $('select').material_select('destroy');
+    }
   };
 })();
 
-document.addEventListener('turbolinks:load', analytics.trackView);
+document.addEventListener('turbolinks:load', window.App.onPageLoad);
+document.addEventListener('turbolinks:visit', window.App.onPageOffload);
 
 // Initialize the app on the first load only.
 window.addEventListener('load', window.App.init);

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -578,6 +578,26 @@ section.row:not(:first-child) {
   color: $color-text-caption;
 }
 
+.select-wrapper {
+  & ~ label {
+    display: block;
+    width: 100%;
+  }
+
+  & ~ label.active {
+    top: 12px;
+  }
+
+  &.invalid ~ label:after {
+    content: attr(data-error);
+    color: $input-error-color;
+    display: block;
+    position: absolute;
+    top: 60px;
+    opacity: 1;
+  }
+}
+
 // This rule overrides the Materialize CSS rules for checkbox labels.
 [type="checkbox"] + .app-checkbox-with-label {
   @extend %app-typography--body-1;

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -32,6 +32,7 @@
 @import "materialize/components/grid";
 @import "materialize/components/typography";
 @import "materialize/components/forms/forms";
+@import "materialize/components/dropdown";
 
 $app-column-outer-width: unquote("calc(" + (100 / $num-cols) + "% + " +
   ($gutter-width / 2)+ ")");

--- a/app/lib/advocate_list.rb
+++ b/app/lib/advocate_list.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+# Simple class to encapsulate the logic of listing advocates
+class AdvocateList
+  ADVOCATE_CSV_URL = 'https://docs.google.com/spreadsheets/d/1kDpMM3Ls44NuPUkluSo6dUwMTseSGLS3K1GqteYxisY/pub?gid=0&single=true&output=csv'
+  ADVOCATE_CSV_PATH = File.expand_path('../../../config/advocates.csv', __FILE__)
+
+  class << self
+    # The CSV can be downloaded with `bin/rails casecompanion:download_advocate_spreadsheet`
+    # TODO: Download this list at deploy-time as well.
+    def all
+      @_list ||= begin
+                  csv = CSV.parse(File.read(ADVOCATE_CSV_PATH).strip, headers: :first_row)
+                  csv.find_all { |r| r['First Name'].present? }.map(&:to_h)
+                end
+    end
+
+    def name_and_emails
+      all.map { |r| [formatted_advocate_name(r), r['Email']] }
+    end
+
+    private
+
+    def formatted_advocate_name(row)
+      properly_capitalized_last = row['Last Name']
+      properly_capitalized_last.capitalize! if properly_capitalized_last.match?(/^[A-Z\-]+$/)
+
+      "#{row['First Name']} #{properly_capitalized_last}"
+    end
+  end
+end

--- a/app/lib/advocate_list.rb
+++ b/app/lib/advocate_list.rb
@@ -18,7 +18,9 @@ class AdvocateList
     end
 
     def name_and_emails
-      all.map { |r| [formatted_advocate_name(r), r['Email']] }
+      all
+        .map { |r| [formatted_advocate_name(r), r['Email']] }
+        .sort_by(&:first)
     end
 
     private

--- a/app/models/rights_flow.rb
+++ b/app/models/rights_flow.rb
@@ -7,6 +7,7 @@
 class RightsFlow
   include ActiveModel::Model
   include ActiveModel::AttributeMethods
+  extend ActiveModel::Translation
 
   # The attributes of this model which will be set by <form> elements. These
   # fields will all be persisted in the flow cookie.

--- a/app/models/rights_flow.rb
+++ b/app/models/rights_flow.rb
@@ -28,6 +28,7 @@ class RightsFlow
     email
     phone_number
     case_number
+    advocate_email
     court_case_subscription_id
   ].freeze
 
@@ -60,6 +61,7 @@ class RightsFlow
         errors.add(:email, :blank) unless email.present?
         errors.add(:phone_number, :blank) unless phone_number.present?
         errors.add(:case_number, :blank) unless case_number.present?
+        errors.add(:advocate_email, :blank) unless advocate_email.present?
       end
     end
   end
@@ -99,6 +101,7 @@ class RightsFlow
       last_name: last_name,
       email: email,
       phone_number: phone_number,
+      advocate_email: advocate_email,
     )
 
     if subscription.persisted? &&

--- a/app/views/rights/_create_account.html.haml
+++ b/app/views/rights/_create_account.html.haml
@@ -44,3 +44,9 @@
     = link_to 'Look up the Case Number',
       'http://mcda.us/index.php/case-information/case-status/',
       class: 'app-typography--caption', target: '_blank'
+
+  .col.s5
+    .input-field
+      = f.select :advocate_email,
+        options_for_select(AdvocateList.name_and_emails, @flow.advocate_email)
+      = f.label :advocate_email, 'Advocate Name'

--- a/app/views/rights/_create_account.html.haml
+++ b/app/views/rights/_create_account.html.haml
@@ -48,5 +48,6 @@
   .col.s5
     .input-field
       = f.select :advocate_email,
-        options_for_select(AdvocateList.name_and_emails, @flow.advocate_email)
-      = f.label :advocate_email, 'Advocate Name'
+        options_for_select(AdvocateList.name_and_emails, @flow.advocate_email),
+        include_blank: true
+      = f.label :advocate_email

--- a/config/advocates.csv
+++ b/config/advocates.csv
@@ -1,0 +1,18 @@
+CRIMES ID,Last Name,First Name,Email,Phone 1,Phone 2
+BONETTK,BONETTI,Kendra,kendra.bonetti@mcda.us,(503) 988-4259,
+BRUNI,BRUNI,Malia,malia.bruni@mcda.us,(503) 988-4871,
+HYDE,HYDE,Emily,emily.hyde@mcda.us,(503) 988-6448,
+JACOBS,JACOBS,Julie,julie.jacobs@mcda.us,(503) 988-3116,
+KANH,KANHALIKHAM,Soukthavy,soukthavy.kanhalikham@mcda.us,(503) 988-4462,
+LARDA,LARD,Allie,allie.lard@mcda.us,(503) 988-9541,
+LOUDEN,LOUDEN,Laurie,laurie.louden@mcda.us,(503) 988-5715,(503) 988-5320
+NEHF,NEHF,Saron,saron.nehf@mcda.us,(503) 988-4719,
+CLARK,Phillips-Clark,Kimberly,kimberly.phillips-clark@mcda.us,(503) 988-3017,
+THOMAC,THOMAS,Chanel,chanel.thomas@mcda.us,(503) 988-5856,
+THOMASME,THOMAS,Meredith,meredith.thomas@mcda.us,(503) 988-6567,
+VILLALI,VILLA,Libby,libby.villa@mcda.us,(503) 988-5845,(503) 988-5026
+FRAZIER,,,,,
+MCMENAMIN,,,,,
+ADKERSK,,,,,
+CHRISTY,,,,,
+PENA,,,,,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,6 +39,14 @@ en:
       (503) 988-3222<br>
       <a href="http://www.mcda.us" target="_blank">www.mcda.us</a>
 
+  activemodel:
+    attributes:
+      rights_flow:
+        # HACK: Since we're showing a <select> with the label "Advocate Name"
+        # but it actually persists as an "advocate_email", we need to fudge the
+        # attribute name for purposes of error messages and such.
+        advocate_email: 'Advocate Name'
+
   rights:
     flag_a:
       I want the District Attorney to assert and enforce my rights to the

--- a/db/migrate/20170817202939_add_advocate_email_to_court_case_subscriptions.rb
+++ b/db/migrate/20170817202939_add_advocate_email_to_court_case_subscriptions.rb
@@ -1,0 +1,7 @@
+class AddAdvocateEmailToCourtCaseSubscriptions < ActiveRecord::Migration[5.0]
+  def change
+    change_table :court_case_subscriptions do |t|
+      t.string :advocate_email
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170816185333) do
+ActiveRecord::Schema.define(version: 20170817202939) do
 
   create_table "ahoy_messages", force: :cascade do |t|
     t.string   "token"
@@ -41,13 +41,14 @@ ActiveRecord::Schema.define(version: 20170816185333) do
 
   create_table "court_case_subscriptions", force: :cascade do |t|
     t.integer  "user_id"
-    t.string   "case_number",  null: false
+    t.string   "case_number",    null: false
     t.string   "first_name"
     t.string   "last_name"
     t.string   "email"
     t.string   "phone_number"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
+    t.string   "advocate_email"
     t.index ["user_id"], name: "index_court_case_subscriptions_on_user_id"
   end
 

--- a/lib/tasks/download_advocate_spreadsheet.rake
+++ b/lib/tasks/download_advocate_spreadsheet.rake
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+namespace :casecompanion do
+  desc 'Update the config/advocates.csv file'
+  task download_advocate_spreadsheet: :environment do
+    puts "Downloading #{AdvocateList::ADVOCATE_CSV_URL}..."
+    puts "  to #{AdvocateList::ADVOCATE_CSV_PATH}"
+
+    File.open(AdvocateList::ADVOCATE_CSV_PATH, 'w') do |f|
+      body = Net::HTTP.get(URI(AdvocateList::ADVOCATE_CSV_URL))
+      f.puts body
+    end
+  end
+end

--- a/spec/requests/rights_flow_spec.rb
+++ b/spec/requests/rights_flow_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe 'Rights selection flow' do
         'email' => 'tom@example.com',
         'phone_number' => '330 555 1234',
         'case_number' => '17CR1234',
+        'advocate_email' => 'advocate@example.com',
       },
     }
     follow_redirect!
@@ -51,6 +52,8 @@ RSpec.describe 'Rights selection flow' do
 
     expect(last_subscription.email)
       .to eq('tom@example.com')
+    expect(last_subscription.advocate_email)
+      .to eq('advocate@example.com')
   end
 
   it 'allows hitting back and saving an updated version' do

--- a/spec/requests/rights_flow_spec.rb
+++ b/spec/requests/rights_flow_spec.rb
@@ -79,6 +79,7 @@ RSpec.describe 'Rights selection flow' do
         'email' => 'tom@example.com',
         'phone_number' => '330 555 1234',
         'case_number' => '17CR1234',
+        'advocate_email' => 'advocate@example.com',
       },
     }
     follow_redirect!


### PR DESCRIPTION
In order for us to send email to a victim's advocate, we need to know
who they are. This adds a "Advocate Name" dropdown on the final page of
the rights flow, which persists the Email of the advocate in the
CourtCaseSubscription object.

The data for this is checked-in as a CSV, although eventually this
should be either managed in-app or automatically fetched at deploy-time.