### PR TITLE
Make email and phone number non-required in digital VRN

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,3 +52,6 @@ Style/ClassAndModuleChildren:
 
 Lint/IneffectiveAccessModifier:
   Enabled: false
+
+Lint/UnneededDisable:
+  Enabled: false

--- a/app.json
+++ b/app.json
@@ -1,6 +1,7 @@
 {
   "name": "casecompanion",
   "scripts": {
+    "postdeploy": "bin/rails db:schema:load"
   },
   "env": {
     "APP_DOMAIN": {

--- a/app/controllers/rights_controller.rb
+++ b/app/controllers/rights_controller.rb
@@ -94,9 +94,11 @@ class RightsController < ApplicationController
   def send_rights_confirmation_email(subscription_id)
     subscription = CourtCaseSubscription.find(subscription_id)
 
-    RightsMailer
-      .vrn_receipt(subscription)
-      .deliver_now
+    if subscription.email.present?
+      RightsMailer
+        .vrn_receipt(subscription)
+        .deliver_now
+    end
 
     RightsMailer
       .vrn_advocate_update(subscription)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,6 +19,8 @@ module ApplicationHelper
 
   # Given a phone number like '+11234567890', returns '(123) 456-7890'
   def format_phone(phone_number)
+    return if phone_number.nil?
+
     local_number = phone_number
       .gsub(/^\+1/, '')
       .delete('-')

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,7 +19,7 @@ module ApplicationHelper
 
   # Given a phone number like '+11234567890', returns '(123) 456-7890'
   def format_phone(phone_number)
-    return if phone_number.nil?
+    return if phone_number.blank?
 
     local_number = phone_number
       .gsub(/^\+1/, '')

--- a/app/models/court_case_subscription.rb
+++ b/app/models/court_case_subscription.rb
@@ -6,11 +6,6 @@ class CourtCaseSubscription < ActiveRecord::Base
   has_many :checked_rights, class_name: 'Right', dependent: :destroy
 
   validates :case_number, presence: true
-  validate :ensure_contact_information
-
-  def ensure_contact_information
-    user.present? || email.present? || phone_number.present?
-  end
 
   def rights_hash
     Hash[Right::RIGHTS.values.map { |right| [right, false] }]

--- a/app/models/rights_flow.rb
+++ b/app/models/rights_flow.rb
@@ -65,8 +65,6 @@ class RightsFlow
       unless court_case_subscription_id.present?
         errors.add(:first_name, :blank) unless first_name.present?
         errors.add(:last_name, :blank) unless last_name.present?
-        errors.add(:email, :blank) unless email.present?
-        errors.add(:phone_number, :blank) unless phone_number.present?
         errors.add(:case_number, :blank) unless case_number.present?
         errors.add(:advocate_email, :blank) unless advocate_email.present?
       end

--- a/app/views/rights/_create_account.html.haml
+++ b/app/views/rights/_create_account.html.haml
@@ -1,13 +1,10 @@
 .row
   .col.s10.offset-s1
-    %p
-      Last step, almost done!
-      %br
-      Tell us about you so we can save your request.
+    %p= simple_format(t('rights_flow.create_account.preamble'))
 
 %section.row
   .col.s10.offset-s1
-    %h2.app-typography--header-2 How can we reach you?
+    %h2.app-typography--header-2= t('rights_flow.create_account.header')
 
 .row
   .col.s5.offset-s1

--- a/app/views/rights_mailer/vrn_advocate_update.html.haml
+++ b/app/views/rights_mailer/vrn_advocate_update.html.haml
@@ -15,11 +15,11 @@ Case details:
 
   %li
     Phone Number:
-    #{format_phone(@subscription.phone_number)}
+    #{format_phone(@subscription.phone_number) || 'Not Provided'}
 
   %li
     Email Address:
-    #{@subscription.email}
+    #{@subscription.email.presence || 'Not Provided'}
 
   %li
     Case Number:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -136,6 +136,11 @@ en:
       preamble:
         There are additional rights in some special cases.
       field_header: Rights in special situations
+    create_account:
+      preamble: |
+        Last step, almost done!
+        Tell us about you so we can save your request.
+      header: How can we reach you?
     confirmation:
       preamble: Review and submit. If the information is correct, type your name below and hit Submit. To edit, hit Back.
       header: "You've selected the following:"

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -17,6 +17,10 @@ describe ApplicationHelper do
   end
 
   describe '#format_phone' do
+    it 'return nil if nil is given' do
+      expect(helper.format_phone(nil)).to be_nil
+    end
+
     it 'formats a phone number as intended' do
       expect(helper.format_phone('+11234567890')).to eq('(123) 456-7890')
     end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -19,6 +19,7 @@ describe ApplicationHelper do
   describe '#format_phone' do
     it 'return nil if nil is given' do
       expect(helper.format_phone(nil)).to be_nil
+      expect(helper.format_phone('')).to be_nil
     end
 
     it 'formats a phone number as intended' do

--- a/spec/requests/rights_flow_spec.rb
+++ b/spec/requests/rights_flow_spec.rb
@@ -201,7 +201,12 @@ RSpec.describe 'Rights selection flow' do
     end
 
     context 'without a phone number or email' do
-      let(:account_params) { valid_account_params.without('phone_number', 'email') }
+      let(:account_params) do
+        valid_account_params.merge(
+          'phone_number' => '',
+          'email' => '',
+        )
+      end
 
       it 'persists the account details' do
         subject

--- a/spec/requests/rights_flow_spec.rb
+++ b/spec/requests/rights_flow_spec.rb
@@ -26,16 +26,24 @@ RSpec.describe 'Rights selection flow' do
     follow_redirect!
     expect(response.body).to include('How can we reach you?')
 
-    post '/rights/create_account', params: {
-      rights_flow: {
-        'first_name' => 'Tom',
-        'last_name' => 'Example',
-        'email' => 'tom@example.com',
-        'phone_number' => '330 555 1234',
-        'case_number' => '1000000',
-        'advocate_email' => FAKE_ADVOCATE_EMAIL,
-      },
+    valid_rights_flow_params = {
+      'first_name' => 'Tom',
+      'last_name' => 'Example',
+      'email' => 'tom@example.com',
+      'phone_number' => '330 555 1234',
+      'case_number' => '1000000',
+      'advocate_email' => FAKE_ADVOCATE_EMAIL,
     }
+
+    # Attempt to proceed with a missing required field, to assert that it does
+    # not let you proceed.
+    post '/rights/create_account', params: {
+      rights_flow: valid_rights_flow_params.except('case_number'),
+    }
+    expect(response.body).to include(I18n.t('rights_flow.create_account.header'))
+    expect(response.body).to include("Case number can't be blank")
+
+    post '/rights/create_account', params: { rights_flow: valid_rights_flow_params }
     follow_redirect!
     expect(response.body).to include(I18n.t('rights_flow.confirmation.header'))
 


### PR DESCRIPTION
In our user testing, we discovered that many people don't have a working
phone number or email address. To allow these users through the flow we
should make these fields optional.

To verify this, I made the already-somewhat-crazy request spec a bit
crazier that it stops progression when a required field is missing.