### PR TITLE
Make FeedbackResponse "page" property optional

### DIFF
--- a/app/controllers/feedback_responses_controller.rb
+++ b/app/controllers/feedback_responses_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class FeedbackResponsesController < ApplicationController
-  DEFAULT_PAGE = 'vrn-confirmation'
-
   layout 'focused'
 
   def show
@@ -15,7 +13,7 @@ class FeedbackResponsesController < ApplicationController
                   FeedbackResponse.find(params[:previous_feedback_id])
                 else
                   FeedbackResponse.create(
-                    page: params[:page].presence || DEFAULT_PAGE,
+                    page: params[:page].presence || params[:utm_campaign],
                     value: params[:type],
                     utm_attribution: UtmAttribution.new_from_params(params),
                   )

--- a/app/helpers/feedback_responses_helper.rb
+++ b/app/helpers/feedback_responses_helper.rb
@@ -60,4 +60,10 @@ module FeedbackResponsesHelper
       raw('&larr; Go Back')
     end
   end
+
+  # If the email is a VRN receipt, we want to render different header/footer.
+  def vrn_receipt?(feedback)
+    feedback.page == 'vrn-confirmation' || # legacy name
+      feedback.page == 'vrn_receipt' # from: RightsMailer#vrn_receipt
+  end
 end

--- a/app/views/feedback_responses/create.html.haml
+++ b/app/views/feedback_responses/create.html.haml
@@ -1,11 +1,11 @@
 - content_for :header do
-  - if @feedback.page == 'vrn-confirmation'
+  - if vrn_receipt?(@feedback)
     %p= t('feedback_responses.header')
   - else
     = render_component 'logo'
 
 - content_for :footer do
-  - if @feedback.page == 'vrn-confirmation'
+  - if vrn_receipt?(@feedback)
     = image_tag 'seal_DA.png', width: '60', height: '61', class: 'app-feedback-footer__logo'
     = simple_format(t('feedback_responses.footer'), class: 'app-feedback-footer__text')
   - else
@@ -35,7 +35,7 @@
   .row
     .col.s10.offset-s1
       .input-field
-        - thing_key = @feedback.page == 'vrn-confirmation' ? 'thing_email' : 'thing_page'
+        - thing_key = vrn_receipt?(@feedback) ? 'thing_email' : 'thing_page'
         = f.label :body, t("feedback_responses.#{@feedback.value}.field_label",
           thing: t("feedback_responses.#{thing_key}"))
         = f.text_field :body, 'data-length': 200, autofocus: true

--- a/app/views/feedback_responses/update.html.haml
+++ b/app/views/feedback_responses/update.html.haml
@@ -1,11 +1,11 @@
 - content_for :header do
-  - if @feedback.page == 'vrn-confirmation'
+  - if vrn_receipt?(@feedback)
     %p= t('feedback_responses.header')
   - else
     = render_component 'logo'
 
 - content_for :footer do
-  - if @feedback.page == 'vrn-confirmation'
+  - if vrn_receipt?(@feedback)
     = image_tag 'seal_DA.png', width: '60', height: '61', class: 'app-feedback-footer__logo'
     = simple_format(t('feedback_responses.footer'), class: 'app-feedback-footer__text')
   - else
@@ -23,7 +23,7 @@
     %p.app-typography--body-1
       Thanks again!
 
-    - if @feedback.page == 'vrn-confirmation'
+    - if vrn_receipt?(@feedback)
       %h2.app-typography--header-2 Want to help make this email better?
 
       %p.app-typography--body-1

--- a/db/migrate/20170831224008_make_feedback_response_page_nullable.rb
+++ b/db/migrate/20170831224008_make_feedback_response_page_nullable.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class MakeFeedbackResponsePageNullable < ActiveRecord::Migration[5.0]
+  def change
+    change_column :feedback_responses, :page, :string, null: true, default: nil
+
+    # backfill existing VRN email feedback responses to have the correct page name
+    utm_attribution = UtmAttribution.where(
+      utm_campaign: 'vrn_receipt',
+      utm_source: 'rights_mailer',
+      utm_medium: 'email',
+    ).first_or_create
+
+    FeedbackResponse.where(page: %w[vrn-confirmation vrn-experiment]).find_all do |response|
+      response.update_attributes(
+        page: 'vrn_receipt',
+        utm_attribution: utm_attribution,
+      )
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170824045109) do
+ActiveRecord::Schema.define(version: 20170831224008) do
 
   create_table "ahoy_messages", force: :cascade do |t|
     t.string   "token"
@@ -53,11 +53,11 @@ ActiveRecord::Schema.define(version: 20170824045109) do
   end
 
   create_table "feedback_responses", force: :cascade do |t|
-    t.integer  "value",                                         null: false
+    t.integer  "value",              null: false
     t.text     "body"
-    t.datetime "created_at",                                    null: false
-    t.datetime "updated_at",                                    null: false
-    t.string   "page",               default: "vrn-experiment", null: false
+    t.datetime "created_at",         null: false
+    t.datetime "updated_at",         null: false
+    t.string   "page"
     t.integer  "utm_attribution_id"
     t.index ["utm_attribution_id"], name: "index_feedback_responses_on_utm_attribution_id"
   end

--- a/spec/controllers/feedback_responses_controller_spec.rb
+++ b/spec/controllers/feedback_responses_controller_spec.rb
@@ -28,9 +28,20 @@ RSpec.describe FeedbackResponsesController, type: :controller do
       expect { subject }.to(change { FeedbackResponse.count }.by(1))
     end
 
-    it 'without a specific page defaults to "vrn-confirmation"' do
+    it 'without a specific page defaults to nil' do
       subject
-      expect(FeedbackResponse.last.page).to eq('vrn-confirmation')
+      expect(response.body).to include(I18n.t('footer.powered_by_html'))
+      expect(FeedbackResponse.last.page).to be_nil
+    end
+
+    describe 'when giving feedback about the digital VRN receipt email' do
+      let(:params) { super().merge(utm_campaign: 'vrn_receipt') }
+
+      it 'creates a feedback response with that page and renders the email version' do
+        subject
+        expect(response.body).to include(I18n.t('feedback_responses.header'))
+        expect(FeedbackResponse.last.page).to eq('vrn_receipt')
+      end
     end
 
     describe 'when giving feedback about a specific page' do


### PR DESCRIPTION
Previously this was either given or it defaulted to the
'vrn-confirmation' page. Since the email now includes a `utm_campaign`
that can be used to determine the page/attribution for the
FeedbackResponse, we can change the logic to not make it default to that
value anymore when page is not provided.

I also included a backfill script which will hopefully catch all
feedback the email and standardize their page values.