### PR TITLE
	Add email that goes to DDAs when rights are requested

### DIFF
--- a/app/controllers/rights_controller.rb
+++ b/app/controllers/rights_controller.rb
@@ -103,6 +103,12 @@ class RightsController < ApplicationController
         .deliver_now
     end
 
+    if subscription.dda_email.present?
+      RightsMailer
+        .vrn_dda_update(subscription)
+        .deliver_now
+    end
+
     RightsMailer
       .vrn_advocate_update(subscription)
       .deliver_now

--- a/app/mailers/rights_mailer.rb
+++ b/app/mailers/rights_mailer.rb
@@ -18,19 +18,37 @@ class RightsMailer < ApplicationMailer
     @subscription = court_case_subscription
 
     remove_feedback_section!
-
-    pdf_name = %W[
-      VRN
-      #{@subscription.case_number}
-      #{@subscription.first_name}
-      #{@subscription.last_name}
-    ].join('-') + '.pdf'
-
-    attachments[pdf_name] = RightsPdfGenerator.new(@subscription).generate.data
+    generate_and_attach_pdf(@subscription)
 
     mail(
       to: Rails.application.config.vrn_update_email_address,
       subject: "Victim Rights Updated: #{@subscription.first_name} #{@subscription.last_name}",
     )
+  end
+
+  def vrn_dda_update(court_case_subscription)
+    @subscription = court_case_subscription
+    return unless @subscription.dda_email.present?
+
+    remove_feedback_section!
+    generate_and_attach_pdf(@subscription)
+
+    mail(
+      to: @subscription.dda_email,
+      subject: "VRN for Case DA##{@subscription.case_number}",
+    )
+  end
+
+  private
+
+  def generate_and_attach_pdf(subscription)
+    pdf_name = %W[
+      VRN
+      #{subscription.case_number}
+      #{subscription.first_name}
+      #{subscription.last_name}
+    ].join('-') + '.pdf'
+
+    attachments[pdf_name] = RightsPdfGenerator.new(subscription).generate.data
   end
 end

--- a/app/models/rights_flow.rb
+++ b/app/models/rights_flow.rb
@@ -35,6 +35,7 @@ class RightsFlow
     completed_step
     electronic_signature_checked
     electronic_signature_name
+    dda_email
   ].freeze
 
   # The ordered steps of the flow, all of which will be the `id` in the route
@@ -67,6 +68,7 @@ class RightsFlow
         errors.add(:last_name, :blank) unless last_name.present?
         errors.add(:case_number, :blank) unless case_number.present?
         errors.add(:advocate_email, :blank) unless advocate_email.present?
+        errors.add(:dda_email, :blank) unless dda_email.present?
       end
 
       if case_number.present?
@@ -123,6 +125,7 @@ class RightsFlow
       email: email,
       phone_number: phone_number,
       advocate_email: advocate_email,
+      dda_email: dda_email,
     )
 
     if subscription.persisted? &&

--- a/app/views/rights/_create_account.html.haml
+++ b/app/views/rights/_create_account.html.haml
@@ -48,3 +48,9 @@
         options_for_select(AdvocateList.name_and_emails, @flow.advocate_email),
         include_blank: true
       = f.label :advocate_email
+
+.row
+  .col.s5.offset-s1
+    .input-field
+      = f.text_field :dda_email, type: 'email'
+      = f.label :dda_email, 'Attorney Email'

--- a/app/views/rights_mailer/vrn_dda_update.html.haml
+++ b/app/views/rights_mailer/vrn_dda_update.html.haml
@@ -1,0 +1,36 @@
+%h1 Victim Rights Requested
+
+Hello,
+%br
+%br
+You're receiving this email because #{@subscription.first_name} has requested
+Victims' Rights on casecompanion.org.
+%br
+%br
+Case details:
+%ul
+  %li
+    Name:
+    #{@subscription.first_name} #{@subscription.last_name}
+
+  %li
+    Phone Number:
+    #{format_phone(@subscription.phone_number) || 'Not Provided'}
+
+  %li
+    Email Address:
+    #{@subscription.email.presence || 'Not Provided'}
+
+  %li
+    Case Number:
+    #{@subscription.case_number}
+
+- if @subscription.checked_rights.any?
+  The following rights are selected:
+  %ul
+    - @subscription.checked_rights.each do |right|
+      %li= right.name
+- else
+  The victim completed the VRN form, but did not select any listed rights.
+
+If you believe there has been an error in this email, please report it to #{link_to 'team@casecompanion.org', 'mailto:team@casecompanion.org'}.

--- a/db/migrate/20170921185207_add_dda_email_to_court_case_subscription.rb
+++ b/db/migrate/20170921185207_add_dda_email_to_court_case_subscription.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddDdaEmailToCourtCaseSubscription < ActiveRecord::Migration[5.0]
+  def change
+    change_table :court_case_subscriptions do |t|
+      t.string :dda_email
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170831224008) do
+ActiveRecord::Schema.define(version: 20170921185207) do
 
   create_table "ahoy_messages", force: :cascade do |t|
     t.string   "token"
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 20170831224008) do
     t.datetime "created_at",     null: false
     t.datetime "updated_at",     null: false
     t.string   "advocate_email"
+    t.string   "dda_email"
     t.index ["user_id"], name: "index_court_case_subscriptions_on_user_id"
   end
 

--- a/spec/mailers/previews/rights_mailer_preview.rb
+++ b/spec/mailers/previews/rights_mailer_preview.rb
@@ -10,6 +10,10 @@ class RightsMailerPreview < ActionMailer::Preview
     RightsMailer.vrn_advocate_update(sample_subscription)
   end
 
+  def vrn_dda_update
+    RightsMailer.vrn_dda_update(sample_subscription)
+  end
+
   private
 
   def sample_subscription
@@ -18,8 +22,10 @@ class RightsMailerPreview < ActionMailer::Preview
       last_name: 'Jones',
       email: 'mary@example.com',
       phone_number: '415-555-1234',
-      case_number: '17CR1234',
+      case_number: '1000000',
       advocate_email: AdvocateList.name_and_emails.first.last,
+      dda_email: 'some.dda@example.com',
+      created_at: 1.hour.ago,
       checked_rights: [
         Right.new(name: 'A-DDA to assert and enforce Victim Rights'),
         Right.new(name: 'B-Notified in advance of Critical Stage Proceedings'),

--- a/spec/mailers/rights_mailer_spec.rb
+++ b/spec/mailers/rights_mailer_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe RightsMailer, type: :mailer do
       phone_number: '415-555-1234',
       case_number: '17CR1234',
       advocate_email: FAKE_ADVOCATE_EMAIL,
+      dda_email: 'some.dda@example.com',
+      created_at: 1.week.ago,
       checked_rights: [
         Right.new(name: 'A-DDA to assert and enforce Victim Rights'),
         Right.new(name: 'B-Notified in advance of Critical Stage Proceedings'),
@@ -37,6 +39,15 @@ RSpec.describe RightsMailer, type: :mailer do
 
     it 'renders' do
       expect(subject.subject).to include('Victim Rights Updated')
+      expect(subject.body.encoded).to include(subscription.email)
+    end
+  end
+
+  describe 'vrn_dda_update' do
+    subject { described_class.vrn_dda_update(subscription) }
+
+    it 'renders' do
+      expect(subject.subject).to include("DA##{subscription.case_number}")
       expect(subject.body.encoded).to include(subscription.email)
     end
   end

--- a/spec/requests/rights_flow_spec.rb
+++ b/spec/requests/rights_flow_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe 'Rights selection flow' do
         'phone_number' => '330 555 1234',
         'case_number' => '1000000',
         'advocate_email' => FAKE_ADVOCATE_EMAIL,
+        'dda_email' => 'tom+dda@example.com',
       },
     }
     follow_redirect!
@@ -97,6 +98,7 @@ RSpec.describe 'Rights selection flow' do
         'phone_number' => '330 555 1234',
         'case_number' => '1000000',
         'advocate_email' => FAKE_ADVOCATE_EMAIL,
+        'dda_email' => 'tom+dda@example.com',
       },
     }
     follow_redirect!
@@ -160,6 +162,7 @@ RSpec.describe 'Rights selection flow' do
         'phone_number' => '330 555 1234',
         'case_number' => '1000000',
         'advocate_email' => FAKE_ADVOCATE_EMAIL,
+        'dda_email' => 'tom+dda@example.com',
       }
     end
 
@@ -197,6 +200,8 @@ RSpec.describe 'Rights selection flow' do
           .to eq('tom@example.com')
         expect(last_subscription.advocate_email)
           .to eq(FAKE_ADVOCATE_EMAIL)
+        expect(last_subscription.dda_email)
+          .to eq('tom+dda@example.com')
       end
     end
 


### PR DESCRIPTION
The email is pretty much a copy of the email that goes to the advocate 
(VRN_UPDATE_EMAIL_ADDRESS), but is meant to be a bit more indexable in a
DDA's inbox. We'll update the design of this according to feedback.

[Delivers #151234258]