### PR TITLE
Extract offender page notifications from FAQs into own section

### DIFF
--- a/app/assets/stylesheets/offenders.scss
+++ b/app/assets/stylesheets/offenders.scss
@@ -1,3 +1,13 @@
 // Place all the styles related to the offenders controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+
+.app-offender-method-container {
+  margin-bottom: 40px;
+  overflow: auto;
+}
+
+.app-offender-notification-method {
+  float: left;
+  width: 50%;
+}

--- a/app/views/offenders/_faq_prison_jail.html.haml
+++ b/app/views/offenders/_faq_prison_jail.html.haml
@@ -2,25 +2,3 @@
 = render_component 'dropdown', title: t("#{dropdown_key}.title") do
   .app-faq-item
     = faq_format(t("#{dropdown_key}.body"))
-
-= render_component 'dropdown', title: 'How can I stay informed about where the offender is?' do
-  %h3.app-typography--body-1
-    %strong Oregon VINE
-  %p
-    VINE is an automated notification system. For example, VINE will call,
-    text, and/or email you if there is a change in custody status.
-  = render_component 'button', to: vine_path(@offender[:sid]) do
-    VINE website
-    %i.material-icons open_in_new
-
-  %h3.app-typography--body-1
-    %strong Oregon Prison Release Notification
-  %p
-    The Oregon Parole Board can notify you 90 days prior to an inmate's
-    release and help you get a No Contact order added to an inmate's
-    conditions of Post-Prison Supervision.
-  - pps_form = 'https://www.oregon.gov/BOPPPS/docs/Fillable%20Forms/Victim%20Request%20for%20Notification.pdf'
-  = render_component 'button', to: pps_form do
-    Sign Up Form
-    %i.material-icons open_in_new
-

--- a/app/views/offenders/_faq_probation.html.haml
+++ b/app/views/offenders/_faq_probation.html.haml
@@ -1,7 +1,3 @@
 = render_component 'dropdown', title: t('offender.probation_faq_1_title') do
   .app-faq-item
     = faq_format(t('offender.probation_faq_1'))
-
-= render_component 'dropdown', title: t('offender.probation_faq_2_title') do
-  .app-faq-item
-    = faq_format(t('offender.probation_faq_2'))

--- a/app/views/offenders/_notifications_prison_jail.html.haml
+++ b/app/views/offenders/_notifications_prison_jail.html.haml
@@ -1,0 +1,12 @@
+.app-offender-method-container
+  .app-offender-notification-method
+    %h3.app-typography--caption-above Status Notifications
+    = link_to 'Sign up with VINE', vine_path(@offender[:sid])
+
+  .app-offender-notification-method
+    %h3.app-typography--caption-above Release Notifications
+    - pps_form = 'https://www.oregon.gov/BOPPPS/docs/Fillable%20Forms/Victim%20Request%20for%20Notification.pdf'
+    = link_to 'Sign up with the Oregon Parole Board', pps_form, target: '_blank'
+
+= render_component 'dropdown', title: t('offender.notification_dropdown_title') do
+  = faq_format(t('offender.prison_notification_difference'))

--- a/app/views/offenders/_notifications_probation.html.haml
+++ b/app/views/offenders/_notifications_probation.html.haml
@@ -1,0 +1,13 @@
+- dcj_form = 'https://multco.us/dcj/victims-services/webform/crime-victims-request-hearing-notification'
+
+.app-offender-method-container
+  .app-offender-notification-method
+    %h3.app-typography--caption-above Status Notifications
+    = link_to 'Sign up with VINE', vine_path(@offender[:sid]), target: '_blank'
+
+  .app-offender-notification-method
+    %h3.app-typography--caption-above Probation Violation Notifications
+    = link_to 'Sign up with the Department of Community Justice', dcj_form, target: '_blank'
+
+= render_component 'dropdown', title: t('offender.notification_dropdown_title') do
+  = faq_format(t('offender.probation_notification_difference'))

--- a/app/views/offenders/show.html.haml
+++ b/app/views/offenders/show.html.haml
@@ -10,6 +10,16 @@
 
 %section.row
   .col.s10.offset-s1
+    %h2.app-typography--header-2 Notifications
+
+    - case @offender[:jurisdiction].to_sym
+    - when :oregon
+      = render 'offenders/notifications_prison_jail'
+    - when :dcj
+      = render 'offenders/notifications_probation'
+
+%section.row
+  .col.s10.offset-s1
     %h2.app-typography--header-2 Frequently Asked Questions
 
     - case @offender[:jurisdiction].to_sym

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -179,18 +179,20 @@ en:
     saydyie: 'Saydyie DeRosia'
     saydyie_title: 'Victim Services Coordinator, Oregon Department of Corrections'
     how_date_change: 'How might the release date date change?'
+    notification_dropdown_title: "What's the difference?"
+    probation_notification_difference: |
+      VINE is an automated notification system. VINE will call, text, and/or email you if there is a change in custody status. For example, VINE can notify you if the person on probation is taken into custody or changes probation officers.
+
+      The Department of Community Justice can call you with information about any court hearings for probation violations. A common reason for a court hearing is when someone on probation violates a term of their supervision–such as by failing a drug test. If there is a hearing, you have the legal right to attend.
+    prison_notification_difference: |
+      VINE is an automated notification system. For example, VINE will call, text, and/or email you if there is a change in custody status. This includes when an inmate is released from prison or is moved between prisons.
+
+      The Oregon Parole Board can notify you at least 90 days prior to an inmate's release and help you get a No Contact order added to an inmate's conditions of Post-Prison Supervision.
     probation_faq_1_title: 'What are the terms of supervision?'
     probation_faq_1: |
       There are a <a href="https://multco.us/dcj-adult/probation-parole-and-post-prison-supervision/standard-conditions-adult-probation-parole" target="_blank">set of general conditions of supervision</a> that apply in almost every case.
 
       Sometimes there are special conditions of supervision that also apply (such as no-contact orders). To find out if a no-contact order applies in your case, you can call the Parole/Probation Officer.
-    probation_faq_2_title: 'How can I be notified about updates?'
-    probation_faq_2: |
-      <strong>Probation Status Updates</strong>
-      You can <a href="https://www.vinelink.com/#/home/site/38000" target="_blank">sign up for VINE notifications</a> to find out about any changes in supervision (for example, if the offender moves to another county) or if the offender is arrested.
-
-      <strong>Probation Violation Hearings</strong>
-      You can also <a href="https://multco.us/dcj/victims-services/webform/crime-victims-request-hearing-notification" target="_blank">sign up for Probation Violation hearing notification</a> to be informed if there is a probation violation hearing. If there is a hearing, you have the legal right to attend.
 
     probation_who_ppo_title: |
       Parole/Probation Officer, Department of Community Justice<br>


### PR DESCRIPTION
This gives a bit more prominence to the "How can I be notified?"
dropdown content by giving it its own section on the offender page.

I rewrote the content a little bit, but largely just used the existing
content.

[Delivers #151260687]